### PR TITLE
refactor: IEのためのfavicon設定を削除

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href="favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rakutter</title>
   </head>


### PR DESCRIPTION
# 何の対応？
以下はIEのための設定のようだったので削除しました。
- rel="shortcut icon" の `shortcut`
- type="image/x-icon" → SVGを利用していたので `image/svg+xml` に修正

# どう対応した？

# その他
