### PR TITLE
ローカルにDBコンテナを追加

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: '3.9'
 services:
-  react-app:
+  app:
+    container_name: rakutter_app
     build:
       context: .
       dockerfile: web.Dockerfile
@@ -16,6 +17,7 @@ services:
       - db
 
   db:
+    container_name: rakutter_db
     image: mysql:8.1.0
     restart: always
     ports:


### PR DESCRIPTION
# 何の対応？

ローカルのDBコンテナをmysqlで作成しました

# どう対応した？

composeファイルにDBコンテナの定義を追加しました

# その他

動作確認↓
```bash
mysql> show databases;
+--------------------+
| Database           |
+--------------------+
| information_schema |
| mysql              |
| performance_schema |
| rakutter           |
| sys                |
+--------------------+
5 rows in set (0.00 sec)

mysql> use rakutter;
Database changed
mysql> show tables;
Empty set (0.00 sec)
```