### PR TITLE
chore: 外部依存のactionsで使用されるnodeバージョンを更新

### DIFF
--- a/.github/workflows/apiLint.yml
+++ b/.github/workflows/apiLint.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Deno
         uses: denoland/setup-deno@v1
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Deno
         uses: denoland/setup-deno@v1

--- a/.github/workflows/lgtmCat.yml
+++ b/.github/workflows/lgtmCat.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Post Cat
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
時の流れは速いもので、いつのまにかv22がLTSになってしまいました、、、

ということで更新します（v18→v20）